### PR TITLE
Add unit tests for me.zhyd.oauth.utils.GlobalAuthUtil

### DIFF
--- a/src/test/java/me/zhyd/oauth/utils/GlobalAuthUtilTest.java
+++ b/src/test/java/me/zhyd/oauth/utils/GlobalAuthUtilTest.java
@@ -1,0 +1,56 @@
+package me.zhyd.oauth.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GlobalAuthUtilTest {
+
+    @Test
+    public void testGenerateDingTalkSignature() {
+        Assert.assertEquals("mLTZEMqIlpAA3xtJ43KcRT0EDLwgSamFe%2FNis5lq9ik%3D",
+                GlobalAuthUtil.generateDingTalkSignature(
+                        "SHA-256", "1562325753000 "));
+    }
+
+    @Test
+    public void testUrlDecode() {
+        Assert.assertEquals("", GlobalAuthUtil.urlDecode(null));
+        Assert.assertEquals("https://www.foo.bar",
+                GlobalAuthUtil.urlDecode("https://www.foo.bar"));
+        Assert.assertEquals("mLTZEMqIlpAA3xtJ43KcRT0EDLwgSamFe/Nis5lq9ik=",
+                GlobalAuthUtil.urlDecode(
+                        "mLTZEMqIlpAA3xtJ43KcRT0EDLwgSamFe%2FNis5lq9ik%3D"));
+    }
+
+    @Test
+    public void testParseStringToMap() {
+        Assert.assertEquals("{bar=baz}",
+                GlobalAuthUtil.parseStringToMap("foo&bar=baz"));
+    }
+
+    @Test
+    public void testIsHttpProtocol() {
+        Assert.assertFalse(GlobalAuthUtil.isHttpProtocol(""));
+        Assert.assertFalse(GlobalAuthUtil.isHttpProtocol("foo"));
+
+        Assert.assertTrue(GlobalAuthUtil.isHttpProtocol("http://www.foo.bar"));
+    }
+
+    @Test
+    public void testIsHttpsProtocol() {
+        Assert.assertFalse(GlobalAuthUtil.isHttpsProtocol(""));
+        Assert.assertFalse(GlobalAuthUtil.isHttpsProtocol("foo"));
+
+        Assert.assertTrue(
+                GlobalAuthUtil.isHttpsProtocol("https://www.foo.bar"));
+    }
+
+    @Test
+    public void testIsLocalHost() {
+        Assert.assertFalse(GlobalAuthUtil.isLocalHost("foo"));
+
+        Assert.assertTrue(GlobalAuthUtil.isLocalHost(""));
+        Assert.assertTrue(GlobalAuthUtil.isLocalHost("127.0.0.1"));
+        Assert.assertTrue(GlobalAuthUtil.isLocalHost("localhost"));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `me.zhyd.oauth.utils.GlobalAuthUtil` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.