### PR TITLE
Add tests for me.zhyd.oauth.utils.StringUtils

### DIFF
--- a/src/test/java/me/zhyd/oauth/AuthRequestTest.java
+++ b/src/test/java/me/zhyd/oauth/AuthRequestTest.java
@@ -16,7 +16,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthGiteeRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -30,7 +30,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthGithubRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -44,7 +44,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthWeiboRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -58,7 +58,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthDingTalkRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -72,7 +72,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthBaiduRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -86,7 +86,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthCodingRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -100,7 +100,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthTencentCloudRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -114,7 +114,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthOschinaRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -128,7 +128,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthAlipayRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .alipayPublicKey("publicKey")
             .build());
         // 返回授权页面，可自行跳转
@@ -143,7 +143,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthQqRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -157,7 +157,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthWeChatRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -171,7 +171,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthTaobaoRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -185,7 +185,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthGoogleRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -199,7 +199,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthFacebookRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("https://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -213,7 +213,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthDouyinRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -227,7 +227,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthLinkedinRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -241,7 +241,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthMicrosoftRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -255,7 +255,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthMiRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");
@@ -269,7 +269,7 @@ public class AuthRequestTest {
         AuthRequest authRequest = new AuthToutiaoRequest(AuthConfig.builder()
             .clientId("clientId")
             .clientSecret("clientSecret")
-            .redirectUri("redirectUri")
+            .redirectUri("http://redirectUri")
             .build());
         // 返回授权页面，可自行跳转
         authRequest.authorize("state");

--- a/src/test/java/me/zhyd/oauth/utils/StringUtilsTest.java
+++ b/src/test/java/me/zhyd/oauth/utils/StringUtilsTest.java
@@ -1,0 +1,93 @@
+package me.zhyd.oauth.utils;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class StringUtilsTest {
+    @Rule public final ExpectedException thrown =
+        ExpectedException.none();
+
+    @Test
+    public void isEmptyNonEmptyInput() {
+        Assert.assertFalse(StringUtils.isEmpty("non-empty string"));
+    }
+
+    @Test
+    public void isEmptyEmptyInput() {
+        Assert.assertTrue(StringUtils.isEmpty(""));
+    }
+
+    @Test
+    public void isEmptyInputNull() {
+        Assert.assertTrue(StringUtils.isEmpty(null));
+    }
+
+    @Test
+    public void isNotEmptyNonEmptyInput() {
+        Assert.assertTrue(StringUtils.isNotEmpty("non-empty string"));
+    }
+
+    @Test
+    public void isNotEmptyEmptyInput() {
+        Assert.assertFalse(StringUtils.isNotEmpty(""));
+    }
+
+    @Test
+    public void isNotEmptyInputNull() {
+        Assert.assertFalse(StringUtils.isNotEmpty(null));
+    }
+
+    @Test
+    public void appendIfNotContainAppendedStringNotPresent() {
+        // (Check the case where appendStr doesn't occur in str)
+        final String str = "Prefix ";
+        final String appendStr = "suffix";
+        final String otherwise = "should be discarded";
+
+        final String result =
+            StringUtils.appendIfNotContain(str, appendStr, otherwise);
+
+        Assert.assertEquals("Prefix suffix", result);
+    }
+
+    @Test
+    public void appendIfNotContainAppendedStringPresent() {
+        // (Check the case where appendStr occurs in str)
+        final String str = "Prefix ";
+        final String appendStr = "Prefix";
+        final String otherwise = "should be appended";
+
+        final String result =
+            StringUtils.appendIfNotContain(str, appendStr, otherwise);
+
+        Assert.assertEquals("Prefix should be appended", result);
+    }
+
+    @Test
+    public void appendIfNotContainEmptyString() {
+        // (Check the special-case for str being empty)
+        final String str = "";
+        final String appendStr = "should not be appended";
+        final String otherwise = "should also not be appended";
+
+        final String result =
+            StringUtils.appendIfNotContain(str, appendStr, otherwise);
+
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void appendIfNotContainAppendingEmptyString() {
+        // (Check the special-case for appendStr being empty)
+        final String str = "should be kept";
+        final String appendStr = "";
+        final String otherwise = "should also not be appended";
+
+        final String result =
+            StringUtils.appendIfNotContain(str, appendStr, otherwise);
+
+        Assert.assertEquals("should be kept", result);
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `me.zhyd.oauth.utils.StringUtils` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).
Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.

I also addressed a problem with the existing auth tests supplying an invalid URL (one which didn't start with `http://` or `https://`) that was preventing running `mvn test`.